### PR TITLE
Major reduction in bundle size.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-custom-properties",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A React component for applying CSS Variables (Custom Properties)",
   "repository": {
     "type": "git",
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "babel-runtime": "^6.6.1",
-    "lodash": "^4.17.4",
     "prop-types": "^15.5.8"
   }
 }

--- a/src/components/custom-properties.js
+++ b/src/components/custom-properties.js
@@ -62,7 +62,7 @@ class CustomProperties extends Component {
     const nextKeys = Object.keys(next);
     const previousKeys = Object.keys(previous);
     const removedKeys = previousKeys
-      .filter(key => nextKeys.indexOf(key) === -1);
+      .filter(key => typeof next[key] === 'undefined');
 
     nextKeys
       .filter(key => next[key] !== previous[key])

--- a/src/components/custom-properties.js
+++ b/src/components/custom-properties.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import propTypes from 'prop-types';
-import { pullAll } from 'lodash';
 import {
   setStyleProperty,
   removeStyleProperty,
@@ -62,7 +61,8 @@ class CustomProperties extends Component {
   handleNewProperties(next, previous) {
     const nextKeys = Object.keys(next);
     const previousKeys = Object.keys(previous);
-    const removedKeys = pullAll(previousKeys, nextKeys);
+    const removedKeys = previousKeys
+      .filter(key => nextKeys.indexOf(key) === -1);
 
     nextKeys
       .filter(key => next[key] !== previous[key])


### PR DESCRIPTION
Currently, the package is pulling the entire `lodash` package when bundled. (e.g. with webpack)

I replaced `pullAll` with a simple `filter` statement that does the same in this case.

This simple change led to a 15% decrease in my minified bundle size, from 456kB to 386kB.

This is a significant network and parse speed improvement for web applications, so I hope you will consider this change. Thanks!

