### PR TITLE
Only use container element when needed.

### DIFF
--- a/src/__tests__/components/custom-properties.js
+++ b/src/__tests__/components/custom-properties.js
@@ -111,6 +111,32 @@ describe('<CustomProperties />', () => {
         expect(utilities.setStyleProperty.calledWith(FAKE_ROOT_NODE, '--foo', 'bar')).to.equal(true);
         expect(utilities.setStyleProperty.calledWith(FAKE_ROOT_NODE, '--baz', 'bat')).to.equal(true);
       });
+
+      it('directly returns children', () => {
+        const children = (
+          <div>Children</div>
+        );
+        const wrapper = shallow(
+          <CustomProperties
+            properties={{ '--foo': 'bar', '--baz': 'bat' }}
+            global
+          >
+            {children}
+          </CustomProperties>
+        );
+        expect(wrapper.equals(children)).to.equal(true);
+      })
+
+      it('doesn\'t render any extra elements', () => {
+        const wrapper = shallow(
+          <CustomProperties
+            properties={{ '--foo': 'bar', '--baz': 'bat' }}
+            global
+          />
+        );
+
+        expect(wrapper.isEmptyRender()).to.equal(true);
+      })
     });
 
     describe('on unmount', () => {

--- a/src/components/custom-properties.js
+++ b/src/components/custom-properties.js
@@ -76,11 +76,11 @@ class CustomProperties extends Component {
   }
 
   render() {
-    return (
+    return !this.props.global ? (
       <div ref={this.containerRef}>
         {this.props.children}
       </div>
-    );
+    ) : (this.props.children || null);
   }
 }
 


### PR DESCRIPTION
With this change, an unnecessary div element won't be created when there are no children of the component. Also when global is true, it won't wrap the children in a div - instead directly returning them.